### PR TITLE
Add RobotAssistant with tour commands

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,9 @@ import { HashRouter as Router, Route, Routes, NavLink, useLocation } from 'react
 import { Toaster } from '@/components/ui/toaster';
 import { Terminal, Brain, MessageSquare, Lightbulb, Settings, Users, BookOpen, Zap, HelpCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { TourProvider } from '@/context/TourContext';
+import RobotAssistant from '@/components/RobotAssistant';
+import Badges from '@/components/Badges';
 
 import SymbioticDialog from '@/pages/SymbioticDialog';
 import NonLinearLearning from '@/pages/NonLinearLearning';
@@ -25,12 +28,13 @@ const navItems = [
 ];
 
 function App() {
-	return (
-		<Router>
-			<div className="min-h-screen bg-background text-foreground flex flex-col crt-lines relative">
-				<header className="border-b border-primary/50 p-2 flex items-center justify-between sticky top-0 z-10 bg-background/80 backdrop-blur-sm">
-					
-				</header>
+        return (
+                <TourProvider>
+                        <Router>
+                                <div className="min-h-screen bg-background text-foreground flex flex-col crt-lines relative">
+                                        <header className="border-b border-primary/50 p-2 flex items-center justify-between sticky top-0 z-10 bg-background/80 backdrop-blur-sm">
+                                                <Badges />
+                                        </header>
 
 				<main className="flex-grow p-4 overflow-auto">
 					<Routes>
@@ -42,16 +46,18 @@ function App() {
 					</Routes>
 				</main>
 
-				<footer className="border-t border-primary/50 p-2 text-xs text-center text-muted-foreground">
-					<p>
-						Symbiotic Intellectual Domain Terminal (DIST) - Status: Nominal. Protocol: Jailbroken. Current User: Guest
-					</p>
-					<p>&copy; 2025 Uncensored Thought Collective. All rights reversed.</p>
-				</footer>
-				<Toaster />
-			</div>
-		</Router>
-	);
+                                <footer className="border-t border-primary/50 p-2 text-xs text-center text-muted-foreground">
+                                        <p>
+                                                Symbiotic Intellectual Domain Terminal (DIST) - Status: Nominal. Protocol: Jailbroken. Current User: Guest
+                                        </p>
+                                        <p>&copy; 2025 Uncensored Thought Collective. All rights reversed.</p>
+                                </footer>
+                                <RobotAssistant />
+                                <Toaster />
+                        </div>
+                </Router>
+                </TourProvider>
+        );
 }
 
 export default App;

--- a/src/components/Badges.jsx
+++ b/src/components/Badges.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useTour } from '@/context/TourContext';
+
+const Badges = () => {
+  const { completed } = useTour();
+
+  if (!completed.length) return null;
+
+  return (
+    <div className="flex space-x-2">
+      {completed.map((badge) => (
+        <span
+          key={badge}
+          className="px-2 py-1 text-xs border border-primary rounded"
+        >
+          {badge}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default Badges;

--- a/src/components/CommandTerminal.jsx
+++ b/src/components/CommandTerminal.jsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useTour } from '@/context/TourContext';
+
+const CommandTerminal = () => {
+  const { runCommand } = useTour();
+  const [history, setHistory] = useState([]);
+  const [input, setInput] = useState('');
+  const listRef = useRef(null);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    setHistory((h) => [...h, { type: 'user', text: input }]);
+    const res = runCommand(input.trim());
+    setHistory((h) => [...h, { type: 'bot', text: res }]);
+    setInput('');
+  };
+
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight;
+    }
+  }, [history]);
+
+  return (
+    <div className="h-full flex flex-col">
+      <ul ref={listRef} className="flex-1 overflow-y-auto text-sm space-y-1 mb-2">
+        {history.map((msg, i) => (
+          <li key={i} className={msg.type === 'user' ? 'text-primary' : ''}>
+            {msg.type === 'user' ? `> ${msg.text}` : msg.text}
+          </li>
+        ))}
+      </ul>
+      <form onSubmit={handleSubmit}>
+        <input
+          className="w-full bg-transparent border-b border-primary outline-none"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          autoFocus
+        />
+      </form>
+    </div>
+  );
+};
+
+export default CommandTerminal;

--- a/src/components/RobotAssistant.jsx
+++ b/src/components/RobotAssistant.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useTour } from '@/context/TourContext';
+import CommandTerminal from '@/components/CommandTerminal';
+
+const RobotAssistant = () => {
+  const { tourMode, togglePanel } = useTour();
+
+  useEffect(() => {
+    document.body.style.overflow = tourMode ? 'hidden' : '';
+  }, [tourMode]);
+
+  return (
+    <>
+      <button
+        className="fixed bottom-6 right-6 size-14 rounded-full bg-primary text-background flex items-center justify-center shadow-lg hover:scale-110 transition-transform z-50"
+        onClick={togglePanel}
+      >
+        🤖
+      </button>
+      <AnimatePresence>
+        {tourMode && (
+          <>
+            <div
+              className="fixed inset-0 bg-black/50 z-40"
+              onClick={togglePanel}
+            />
+            <motion.aside
+              initial={{ y: '-100%' }}
+              animate={{ y: 0 }}
+              exit={{ y: '-100%' }}
+              transition={{ type: 'tween' }}
+              className="fixed top-0 left-0 right-0 h-[80vh] bg-background z-50 border-b border-primary flex flex-col"
+            >
+              <div className="p-4 border-b border-primary flex items-center space-x-2">
+                <span className="text-2xl">🤖</span>
+                <h2 className="text-lg">Robot Assistant</h2>
+              </div>
+              <CommandTerminal />
+            </motion.aside>
+          </>
+        )}
+      </AnimatePresence>
+    </>
+  );
+};
+
+export default RobotAssistant;

--- a/src/context/TourContext.jsx
+++ b/src/context/TourContext.jsx
@@ -1,0 +1,63 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import script from '@/data/tourScript.json';
+import useTourActions from '@/hooks/useTourActions';
+
+const TourContext = createContext();
+
+export const TourProvider = ({ children }) => {
+  const actions = useTourActions();
+  const [tourMode, setTourMode] = useState(false);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [completed, setCompleted] = useState([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('tourState');
+    if (stored) {
+      const state = JSON.parse(stored);
+      setTourMode(state.tourMode);
+      setCurrentStep(state.currentStep);
+      setCompleted(state.completed || []);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(
+      'tourState',
+      JSON.stringify({ tourMode, currentStep, completed })
+    );
+  }, [tourMode, currentStep, completed]);
+
+  const togglePanel = () => setTourMode((t) => !t);
+
+  const completeStep = (id, badge) => {
+    if (!completed.includes(badge)) {
+      setCompleted((c) => [...c, badge]);
+    }
+    const index = script.findIndex((s) => s.id === id);
+    if (index !== -1) setCurrentStep(index + 1);
+  };
+
+  const runCommand = (cmd) => {
+    const step = script[currentStep];
+    let response = 'Comando no reconocido';
+    if (step && step.command === cmd) {
+      response = step.dialog;
+      const { action, badge, id } = step;
+      if (action.scrollTo) actions.scrollTo(action.scrollTo);
+      if (action.loadModule) actions.loadModule(action.loadModule);
+      if (action.showCertificate) actions.showCertificate();
+      completeStep(id, badge);
+    }
+    return response;
+  };
+
+  return (
+    <TourContext.Provider
+      value={{ tourMode, currentStep, completed, togglePanel, runCommand, completeStep }}
+    >
+      {children}
+    </TourContext.Provider>
+  );
+};
+
+export const useTour = () => useContext(TourContext);

--- a/src/data/tourScript.json
+++ b/src/data/tourScript.json
@@ -1,0 +1,6 @@
+[
+  { "id": "welcome", "command": "start", "dialog": "¡Bienvenido a DIST!...", "action": { "scrollTo": "#about" }, "badge": "Explorador Novato" },
+  { "id": "skills", "command": "next", "dialog": "Chequea mis Skills...", "action": { "scrollTo": "#skills" }, "badge": "Voyeur de Skills" },
+  { "id": "oracle", "command": "oracle", "dialog": "Invocando Oráculo...", "action": { "loadModule": "ThoughtOracles" }, "badge": "Consultor" },
+  { "id": "finish", "command": "finish", "dialog": "Tour completado...", "action": { "showCertificate": true }, "badge": "Explorador DIST" }
+]

--- a/src/hooks/useTourActions.js
+++ b/src/hooks/useTourActions.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { toast } from '@/components/ui/use-toast';
+
+export default function useTourActions() {
+  const scrollTo = (selector) => {
+    const el = document.querySelector(selector);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
+  const loadModule = (name) => {
+    return React.lazy(() => import(`@/pages/${name}.jsx`));
+  };
+
+  const showCertificate = () => {
+    toast({
+      title: 'Certificado',
+      description: 'TODO: Implementar CertificateCanvas',
+    });
+  };
+
+  return { scrollTo, loadModule, showCertificate };
+}


### PR DESCRIPTION
## Summary
- provide global `TourContext` for tour state and commands
- add tour script example and action helpers
- implement `CommandTerminal`, `Badges`, and `RobotAssistant` components
- integrate assistant and badges in the app

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685dc0e94b3c8332a6f51c49cdf7440f